### PR TITLE
Support for emails containing multiple receipts from amazon

### DIFF
--- a/receipt_mail/_mail.py
+++ b/receipt_mail/_mail.py
@@ -37,6 +37,28 @@ class Mail:
         return [part.get_content() for part in self._mail.walk()
                 if not part.is_multipart()]
 
+    def structure(
+            self,
+            indent: str = '    ',
+            include_default: bool = False) -> str:
+        result: List[str] = []
+
+        def _structure(
+                message: email.message.EmailMessage,
+                level: int,
+                include_default: bool) -> None:
+            result.append('{0}{1}{2}'.format(
+                    indent * level,
+                    message.get_content_type(),
+                    ' [{0}]'.format(message.get_default_type())
+                    if include_default else ''))
+            if message.is_multipart():
+                for subpart in message.get_payload():
+                    _structure(subpart, level + 1, include_default)
+
+        _structure(self._mail, 0, include_default)
+        return '\n'.join(result)
+
     def date(self) -> datetime.datetime:
         return self._mail.get('Date').datetime
 

--- a/receipt_mail/_mail.py
+++ b/receipt_mail/_mail.py
@@ -35,7 +35,7 @@ class Mail:
 
     def text_list(self) -> List[str]:
         return [part.get_content() for part in self._mail.walk()
-                if not part.is_multipart()]
+                if part.get_content_type() == 'text/plain']
 
     def structure(
             self,

--- a/receipt_mail/amazon/_mail.py
+++ b/receipt_mail/amazon/_mail.py
@@ -31,7 +31,8 @@ class Mail(MailBase):
         pattern = r'Amazon.co.jp ご注文の確認'
         return bool(re.match(pattern, self.subject()))
 
-    def receipt(self) -> Optional[Receipt]:
+    def receipt(self) -> List[Receipt]:
+        result: List[Receipt] = []
         self.logger.debug(
                 'structure:\n%s',
                 textwrap.indent(self.structure(), '  '))
@@ -67,9 +68,10 @@ class Mail(MailBase):
                         'total payment is mismatch: %d(mail) & %d(result)',
                         _total_payment(order),
                         receipt.total_payment())
-            return receipt
-        self.logger.warning('order is not found')
-        return None
+            result.append(receipt)
+        else:
+            self.logger.warning('order is not found')
+        return result
 
     def order(self) -> Optional[str]:
         if len(self.text_list()) != 1:

--- a/receipt_mail/amazon/_mail.py
+++ b/receipt_mail/amazon/_mail.py
@@ -81,10 +81,10 @@ class Mail(MailBase):
             self.logger.warning('mail has not text/plain')
         pattern = re.compile(
                 r'=+\n'
-                r'\n'
-                r'注文内容\n'
-                r'.+'
-                r'=+\n',
+                r'.+?'
+                r'注文番号：\s*[0-9-]+\s*\n'
+                r'.+?'
+                r'(?==+\n)',
                 flags=re.DOTALL)
         for text in map(lambda x: x.replace('\r\n', '\n'), self.text_list()):
             match = pattern.search(text)
@@ -107,8 +107,8 @@ def _order_id(order: str) -> str:
 def _extract_item_list(order: str) -> Optional[str]:
     match = re.search(
             r'=+\n'
-            r'\n'
-            r'注文内容\n'
+            r'.+?'
+            r'注文番号：\s*[0-9-]+\s*\n'
             r'(?P<item_list>.+?)'
             r'_+\n',
             order,

--- a/receipt_mail/melonbooks/_mail.py
+++ b/receipt_mail/melonbooks/_mail.py
@@ -2,7 +2,7 @@
 
 import datetime
 import re
-from typing import List, NamedTuple, Optional, Tuple
+from typing import List, NamedTuple, Tuple
 from .._mail import Mail as MailBase
 
 
@@ -33,7 +33,8 @@ class Mail(MailBase):
         pattern = '【メロンブックス／フロマージュブックス】 ご注文の確認'
         return self.subject() == pattern
 
-    def receipt(self) -> Optional[Receipt]:
+    def receipt(self) -> List[Receipt]:
+        result: List[Receipt] = []
         if self.is_receipt():
             text = self.text()
             receipt = Receipt(
@@ -46,8 +47,8 @@ class Mail(MailBase):
                 purchased_date=self.date())
             assert receipt.items
             assert receipt.total_payment() == _price('合計額', text)
-            return receipt
-        return None
+            result.append(receipt)
+        return result
 
 
 def _order_id(text: str) -> int:

--- a/receipt_mail/yodobashi/_mail.py
+++ b/receipt_mail/yodobashi/_mail.py
@@ -13,7 +13,7 @@ class Item(NamedTuple):
 
 
 class Receipt(NamedTuple):
-    items: Tuple[Item]
+    items: Tuple[Item, ...]
     shipping: int
     granted_point: int
     purchased_date: datetime.datetime
@@ -27,7 +27,8 @@ class Mail(MailBase):
         pattern = 'ヨドバシ・ドット・コム：ご注文ありがとうございます'
         return self.subject() == pattern
 
-    def receipt(self):
+    def receipt(self) -> List[Receipt]:
+        result: List[Receipt] = []
         text = self.text_list()[0]
         order = _extract_item_list(text)
         if order:
@@ -39,8 +40,8 @@ class Mail(MailBase):
                     shipping=shipping,
                     granted_point=granted_point,
                     purchased_date=self.date())
-            return receipt
-        return None
+            result.append(receipt)
+        return result
 
 
 def _extract_item_list(text: str) -> Optional[str]:

--- a/utility.py
+++ b/utility.py
@@ -22,12 +22,12 @@ class ReceiptBase(Protocol):
     def purchased_date(self) -> datetime.datetime: ...
 
 
-class MailT(Protocol):
+class MailT(Protocol[ReceiptT]):
     def subject(self) -> str: ...
 
     def is_receipt(self) -> bool: ...
 
-    def receipt(self) -> Optional[ReceiptBase]: ...
+    def receipt(self) -> List[ReceiptT]: ...
 
     @classmethod
     def read_file(
@@ -110,7 +110,7 @@ def write_gnucash_csv(
 def aggregate(
         category: str,
         config_path: pathlib.Path,
-        mail_class: Type[MailT],
+        mail_class: Type[MailT[ReceiptT]],
         to_markdown: Callable[[ReceiptT], MarkdownRecord],
         to_gnucash: Callable[[ReceiptT], GnuCashRecord],
         timezone: Optional[datetime.tzinfo] = None,
@@ -134,8 +134,7 @@ def aggregate(
         if not mail.is_receipt():
             logger.info('%s: is not receipt', mail_file.as_posix())
             continue
-        receipt = mail.receipt()
-        if receipt is not None:
+        for receipt in mail.receipt():
             logger.info('%s: %s', mail_file.as_posix(), repr(receipt))
             receipt_list.append(receipt)
         else:


### PR DESCRIPTION
# In case 1 email has multiple receipts

Mail class
- `receipt()` return `List[Receipt]` 

amazon.Mail class
- `order()` return `List[str]`
- change the keyword for parsing from '注文内容' to '注文番号： ...'
  - as a result, it was deal with by changing from '注文内容' to '領収書/購入明細書'

# Logger

Mail class
- add `structure()`
  - mimic `email.iterators._structure(...)`

amazon.Mail class
- add logger output