### PR TITLE
Fix BOOK☆WALKER

### DIFF
--- a/bookwalker.py
+++ b/bookwalker.py
@@ -16,7 +16,7 @@ def translate_title(name: str) -> str:
     name = utility.escape_markdown_symbol(name)
     # remove 【...】
     name = re.sub(r'【[^【】]*(電子|特典|OFF)[^【】]*】', '', name)
-    name = re.sub(r'【(期間限定|)([^【】]+セット)】', ' \g<2>', name)
+    name = re.sub(r'【(期間限定|)([^【】]+セット)】', r' \g<2>', name)
     name = name.strip()
     # '(N)' -> ' N'
     name = re.sub(r'\(([0-9]+)\)$', r' \g<1>', name)

--- a/bookwalker.py
+++ b/bookwalker.py
@@ -22,8 +22,8 @@ def translate_title(name: str) -> str:
     name = re.sub(r'\(([0-9]+)\)$', r' \g<1>', name)
     # ': N' -> ' N'
     name = re.sub(r': ([0-9]+)$', r' \g<1>', name)
-    # 'N巻' -> 'N'
-    name = re.sub(r'([0-9]+)巻$', r'\g<1>', name)
+    # '第?N巻' -> 'N'
+    name = re.sub(r'第?([0-9]+)巻$', r'\g<1>', name)
     # replace continuous space
     name = re.sub(r'\s+', ' ', name)
     # coin

--- a/receipt_mail/bookwalker/_mail.py
+++ b/receipt_mail/bookwalker/_mail.py
@@ -70,7 +70,7 @@ class Mail(MailBase):
                 return ReceiptType.PRE_ORDER
             items = _get_item(order)
             for item in items:
-                if re.match(r'BOOK☆WALKER 期間限定コイン .+', item.name):
+                if re.match(r'BOOK☆WALKER (期間限定)?コイン .+', item.name):
                     return ReceiptType.COIN
             return ReceiptType.ORDER
         return ReceiptType.NONE
@@ -167,7 +167,7 @@ def _get_item(text: str) -> List[Item]:
         book_match = book_regex.search(text)
     # coin
     coin_regex = re.compile(
-            r'■Item\s*[:：]\s*(?P<name>BOOK☆WALKER 期間限定コイン .+)\n'
+            r'■Item\s*[:：]\s*(?P<name>BOOK☆WALKER (期間限定)?コイン .+)\n+'
             r'■Amount\s*[:：]\s*(?P<amount>.+)\n')
     coin_price_regex = re.compile(
             r'■Total Payment\s*[:：]\s*(?P<price>.+)\n')

--- a/receipt_mail/bookwalker/_mail.py
+++ b/receipt_mail/bookwalker/_mail.py
@@ -167,7 +167,7 @@ def _get_item(text: str) -> List[Item]:
         book_match = book_regex.search(text)
     # coin
     coin_regex = re.compile(
-            r'■Item\s*[:：]\s*(?P<name>BOOK☆WALKER (期間限定)?コイン .+)\n+'
+            r'■Item\s*[:：]\s*(?P<name>BOOK☆WALKER (期間限定)?コイン [0-9,]+円分)[^\n]+\n+'
             r'■Amount\s*[:：]\s*(?P<amount>.+)\n')
     coin_price_regex = re.compile(
             r'■Total Payment\s*[:：]\s*(?P<price>.+)\n')


### PR DESCRIPTION
# BOOK☆WALKER

Fix coin buying
- From 2021/12/22, Expiration dates for some coins will be abolished.
  - [【重要なお知らせ】BOOK☆WALKERコイン有効期限についての一部変更](https://bookwalker.jp/info/coin2021/)

Convert title from "第N巻" to "N".

Fix pycodestyle warning

